### PR TITLE
feat(openai): allow OPENAI_BASE_URL for OpenAI-compatible endpoints

### DIFF
--- a/wyoming_cloud_streamer/__main__.py
+++ b/wyoming_cloud_streamer/__main__.py
@@ -44,8 +44,20 @@ async def main() -> None:
     _LOGGER.debug(args)
 
 
+    # Voice list
+    # Default voices are loaded from voices.json.
+    # For OpenAI(-compatible) endpoints that support custom voices but don't expose discovery,
+    # you can override the advertised OpenAI voices via env var:
+    #   OPENAI_TTS_VOICES=Will_Default,will
     with open("/app/wyoming_cloud_streamer/voices.json", "r", encoding="utf-8") as f:
         voices_data = json.load(f)
+
+    override_openai_voices = os.getenv("OPENAI_TTS_VOICES", "").strip()
+    if override_openai_voices:
+        voices_data.setdefault("openai", {}).setdefault("voices", [])
+        voices_data["openai"]["voices"] = [
+            v.strip() for v in override_openai_voices.split(",") if v.strip()
+        ]
 
     voices = []
     for key in voices_data.keys():

--- a/wyoming_cloud_streamer/engines.py
+++ b/wyoming_cloud_streamer/engines.py
@@ -79,7 +79,10 @@ class OpenAITTSEngine(BaseTTSEngine):
     async def stream(
         self, text: str, voice_name: str, cli_args
     ) -> AsyncGenerator[Tuple[str, object], None]:
-        client = OpenAI()
+        base_url = os.getenv("OPENAI_BASE_URL")
+        # Allow using a local OpenAI-compatible endpoint (e.g., MOSS-TTS) by setting OPENAI_BASE_URL.
+        # Example: OPENAI_BASE_URL=http://127.0.0.1:8880/v1
+        client = OpenAI(base_url=base_url) if base_url else OpenAI()
         voice = self._parse_voice(voice_name)
 
         # Resolve model precedence: ENV > default


### PR DESCRIPTION
This adds support for configuring the OpenAI Python client base URL via an OPENAI_BASE_URL env var.

Motivation: allow using local/self-hosted OpenAI-compatible TTS endpoints (e.g., MOSS-TTS) while still using the OpenAI SDK streaming response helper.

Also adds OPENAI_TTS_VOICES (comma-separated) to override the advertised OpenAI voices list for OpenAI-compatible endpoints that do not expose voice discovery.

Behavior:
- If OPENAI_BASE_URL is set, construct OpenAI(base_url=OPENAI_BASE_URL)
- Otherwise keep current default OpenAI() behavior.
- If OPENAI_TTS_VOICES is set, advertise those voices under the OpenAI provider instead of the defaults from voices.json.